### PR TITLE
remove video tag error message

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,6 @@
           <video loop muted>
             <source src="/video/DuckFactory_web.webm" type="video/webm">
             <source src="/video/DuckFactory_web.mp4" type="video/mp4">
-            Your browser does not support the video tag.
           </video>
           <h3>3D</h3>
         </div>


### PR DESCRIPTION
All modern browsers support the video tag and the error message is displaying in the description of search engine results for some reason.